### PR TITLE
force utf-8 encoding

### DIFF
--- a/src/gradio_i18n/i18n.py
+++ b/src/gradio_i18n/i18n.py
@@ -323,7 +323,7 @@ def Translate(translation, lang: gr.components.Component = None, placeholder_lan
     elif isinstance(translation, str):
         if os.path.exists(translation):
             # Regard as a file path
-            with open(translation, "r", encoding=find_encoding(translation)) as f:
+            with open(translation, "r", encoding='utf-8') as f: # Force utf-8 encoding
                 if translation.endswith(".json"):
                     translation_dict = json.load(f)
                 elif translation.endswith(".yaml"):


### PR DESCRIPTION
There is currently a problem when loading certain languages ​​because Windows defaults use the 'charmap' encoding (CP1252), which cannot handle certain Unicode characters. This creates the error:
```
UnicodeDecodeError: 'charmap' codec can't decode byte X in position Y: character maps to <undefined>
```
![image](https://github.com/user-attachments/assets/2e256b90-3cbe-4e79-ac6f-c6af6452d4ba)

To solve this problem it's best to change the way the file is opened to force UTF-8 like this (line 326):
```
with open(translation, "r", encoding='utf-8') as f:  # Force utf-8 encoding
```
![image](https://github.com/user-attachments/assets/07108e52-e424-4723-9d31-4abb935081b2)

This way there will be no problems for any language due to the forced use of UTF-8 encoding.

The previous PR #2 only added support for the language the user is using on their PC. But other languages will still give errors.

References that this way works:
https://github.com/Eddycrack864/UVR5-UI/issues/14
https://github.com/jhj0517/Whisper-WebUI/issues/356