### PR TITLE
Add support for fine-grained language code

### DIFF
--- a/example/basic.py
+++ b/example/basic.py
@@ -10,7 +10,7 @@ def greet(name, gender, lang):
 
 with gr.Blocks() as demo:
     with Translate(
-        "translation.yaml", placeholder_langs=["en", "zh", "ja", "ko", "es", "fr", "de"]
+        "translation.yaml", placeholder_langs=["en", "zh", "zh-Hant", "ja", "ko", "es", "fr", "de"]
     ) as lang:
         name = gr.Textbox(label=_("Name"), placeholder=_("Input your name here."))
         gender = gr.Radio(choices=[_("Male"), _("Female"), _("Unknown")])

--- a/example/change_lang.py
+++ b/example/change_lang.py
@@ -15,6 +15,7 @@ with gr.Blocks() as demo:
         choices=[
             ("English", "en"),
             ("中文", "zh"),
+            ("中文(繁體)", "zh-Hant"),
             ("日本語", "ja"),
             ("한국인", "ko"),
             ("español", "es"),
@@ -26,7 +27,7 @@ with gr.Blocks() as demo:
     with Translate(
         "translation.yaml",
         lang,
-        placeholder_langs=["en", "zh", "ja", "ko", "es", "fr", "de"],
+        placeholder_langs=["en", "zh", "zh-Hant", "ja", "ko", "es", "fr", "de"],
     ):
         name = gr.Textbox(label=_("Name"), placeholder=_("Input your name here."))
         gender = gr.Radio(choices=[_("Male"), _("Female"), _("Unknown")])

--- a/example/translation.yaml
+++ b/example/translation.yaml
@@ -20,6 +20,17 @@ zh:
   Submit: 提交
   Hello {name} {gender} in {lang}: 你好 {name} {gender} 在 {lang}
 
+zh-Hant:
+  Language: 語言
+  Name: 名字
+  Input your name here.: 在這裡輸入您的名字。
+  Male: 男
+  Female: 女
+  Unknown: 未知
+  Greeting: 問候
+  Submit: 送出
+  Hello {name} {gender} in {lang}: 你好 {name} {gender} 在 {lang}
+
 ja:
   Language: 言語
   Name: 名前

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "gradio", "pyyaml"
+    "gradio", "pyyaml", "langcodes"
 ]
 
 [project.urls]

--- a/src/gradio_i18n/i18n.py
+++ b/src/gradio_i18n/i18n.py
@@ -4,7 +4,6 @@ import json
 import os
 import traceback
 from contextlib import contextmanager
-from functools import lru_cache
 
 import gradio as gr
 import yaml
@@ -54,7 +53,7 @@ def get_lang_from_request(request: gr.Request):
         return "en"
     return lang
 
-@lru_cache
+@functools.lru_cache
 def lookup_closest_lang(lang: str, supported_langs: tuple[str]) -> str:
     matched_lang, _ = langcodes.closest_match(lang, supported_langs)
     return matched_lang


### PR DESCRIPTION
Hi, this is a wonderful project that enables the localization of a Gradio-based app. Thanks.

Currently, only the language portion of the language code (e.g., `zh` for Chinese) is used, neglecting regional variations (e.g., `zh-Hans` for Simplified Chinese, `zh-Hant` for Traditional Chinese). This limitation prevents users from receiving regionally appropriate translations.

This patch enhances localization by adding fine-grained language code support.  Using the [langcodes](https://pypi.org/project/langcodes/) package and [IETF BCP 47](https://tools.ietf.org/html/bcp47), it identifies the closest matching language code.
For instance, with both Simplified Chinese (zh-Hans) and Traditional Chinese (zh-Hant) available, a browser specifying `zh-TW` in its `Accept-Language` header will receive the zh-Hant translation, while `zh-CN` will select the zh-Hans translation.