### PR TITLE
check whether "Accept-Language" is in request.headers

### DIFF
--- a/src/gradio_i18n/i18n.py
+++ b/src/gradio_i18n/i18n.py
@@ -62,11 +62,11 @@ class TranslateContext:
 
 
 def get_lang_from_request(request: gr.Request):
-    lang = request.headers["Accept-Language"].split(",")[0]
-    lang, _ = langcodes.closest_match(lang, TranslateContext.get_available_languages())
-
-    if not lang:
-        return "en"
+    if "Accept-Language" in request.headers:
+        lang = request.headers["Accept-Language"].split(",")[0]
+        lang, _ = langcodes.closest_match(lang, TranslateContext.get_available_languages())    # returns "und" (Undetermined language) for no match
+    else:
+        lang = "und"
     return lang
 
 


### PR DESCRIPTION
In some rare cases, there would be no "`Accept-Language`" in `request.headers`, which leads to errors (I found lots of such errors in my server log).

Additionally, `langcodes.closest_match` returns "`und`" for no match rather than `None`, so maybe it is not necessary to check `if not lang:` in line 68.